### PR TITLE
feat: remove user and accesstoken from redux when signout

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -23,6 +23,8 @@ const reducer: Reducer<AuthState, AuthActionsTypes> = (state = initialState, act
       const newState = { ...state, error: action.payload.error };
       delete newState.accessToken;
       return newState;
+    case AuthTypes.SIGNOUT:
+      return initialState;
     default:
       return state;
   }


### PR DESCRIPTION
Added an action in the reducer to remove the user/accesstoken from redux after `SIGNOUT` action is fired.